### PR TITLE
Add `LocationDependency` (#71)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -253,6 +253,13 @@ let package = Package(
       ]
     ),
 
+    .testTarget(
+      name: "_LocationDependencyTests",
+      dependencies: [
+        "_LocationDependency"
+      ]
+    ),
+
     .target(
       name: "LocationManagerDependency",
       dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,7 @@ import PackageDescription
 /// - `CompressionDependency`:         `\.compress` and `\.decompress`
 /// - `DataDependency`:                `\.dataReader` and `\.dataWriter`
 /// - `DeviceDependency`:              `\.device` and `\.deviceCheckDevice`
+/// - `_LocationDependency`:           `\.location`
 /// - `LocationManagerDependency`:     `\.locationManager`
 /// - `LoggerDependency`:              `\.logger`
 /// - `NotificationCenterDependency`:  `\.notificationCenter`
@@ -41,6 +42,7 @@ let package = Package(
     .library(name: "DependenciesAdditions", targets: ["DependenciesAdditions"]),
     .library(name: "_AppStorageDependency", targets: ["_AppStorageDependency"]),
     .library(name: "_CoreDataDependency", targets: ["_CoreDataDependency"]),
+    .library(name: "_LocationDependency", targets: ["_LocationDependency"]),
     .library(name: "_NotificationDependency", targets: ["_NotificationDependency"]),
     .library(name: "_SwiftUIDependency", targets: ["_SwiftUIDependency"]),
   ],
@@ -239,6 +241,15 @@ let package = Package(
       name: "DeviceDependencyTests",
       dependencies: [
         "DeviceDependency"
+      ]
+    ),
+
+    .target(
+      name: "_LocationDependency",
+      dependencies: [
+        .product(name: "Dependencies", package: "swift-dependencies"),
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+        "LocationManagerDependency",
       ]
     ),
 
@@ -450,13 +461,13 @@ func addIndividualProducts() {
 }
 //addIndividualProducts()
 
-//for target in package.targets {
-//  target.swiftSettings = target.swiftSettings ?? []
-//  target.swiftSettings?.append(
-//    .unsafeFlags([
-//      "-Xfrontend", "-warn-concurrency",
-//      "-Xfrontend", "-enable-actor-data-race-checks",
-//      //      "-enable-library-evolution",
-//    ])
-//  )
-//}
+for target in package.targets {
+  target.swiftSettings = target.swiftSettings ?? []
+  target.swiftSettings?.append(
+    .unsafeFlags([
+      "-Xfrontend", "-warn-concurrency",
+      "-Xfrontend", "-enable-actor-data-race-checks",
+      //      "-enable-library-evolution",
+    ])
+  )
+}

--- a/Sources/_LocationDependency/LocationDependency.swift
+++ b/Sources/_LocationDependency/LocationDependency.swift
@@ -7,7 +7,7 @@
   extension DependencyValues {
     /// An abstraction of `CLLocationManager`, the central object for managing
     /// notification-related activities for your app or app extension.
-    public var location: LocationClient {
+    public var locationClient: LocationClient {
       get { self[LocationClient.self] }
       set { self[LocationClient.self] = newValue }
     }
@@ -26,166 +26,143 @@
     }
 
     @_spi(Internals) public var _implementation: Implementation
-  }
 
-
-
-
-enum LocationError: Error {
-  case noLocation, notAuthorized(CLAuthorizationStatus), error(CLError)
-}
-
-enum DelegateError: Swift.Error {
-  case deinitialized
-}
-
-
-final class LocationManagerDelegate: NSObject, CLLocationManagerDelegate {
-  private var locationContinuations: [CheckedContinuation<CLLocationCoordinate2D, any Error>] = []
-  private var authorizationContinuations: [CheckedContinuation<CLAuthorizationStatus, Never>] = []
-
-  deinit {
-    while !self.locationContinuations.isEmpty {
-      self.locationContinuations.removeFirst().resume(throwing: DelegateError.deinitialized)
+    @Sendable
+    public func getLocation() async throws -> CLLocationCoordinate2D {
+      try await self._implementation.getLocation()
     }
   }
 
-  func registerLocationContinuation(_ continuation: CheckedContinuation<CLLocationCoordinate2D, any Error>) {
-    self.locationContinuations.append(continuation)
-  }
-  func registerAuthorizationContinuation(_ continuation: CheckedContinuation<CLAuthorizationStatus, Never>) {
-    self.authorizationContinuations.append(continuation)
+  enum LocationError: Error {
+    case noLocation
+    case notAuthorized(CLAuthorizationStatus)
+    case error(CLError)
   }
 
-  private func locationReceived(_ res: Result<CLLocationCoordinate2D, LocationError>) -> Void {
-    while !self.locationContinuations.isEmpty {
-      self.locationContinuations.removeFirst().resume(with: res)
+  enum DelegateError: Swift.Error {
+    case deinitialized
+  }
+
+  final class LocationManagerDelegate: NSObject, CLLocationManagerDelegate {
+    private var locationContinuations: [CheckedContinuation<CLLocationCoordinate2D, any Error>] = []
+    private var authorizationContinuations: [CheckedContinuation<CLAuthorizationStatus, Never>] = []
+
+    deinit {
+      while !self.locationContinuations.isEmpty {
+        self.locationContinuations.removeFirst().resume(throwing: DelegateError.deinitialized)
+      }
     }
-  }
 
-  func locationManager(_: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-    if let location = locations.first {
-      self.locationReceived(.success(location.coordinate))
-    } else {
-      self.locationReceived(.failure(LocationError.noLocation))
+    func registerLocationContinuation(
+      _ continuation: CheckedContinuation<CLLocationCoordinate2D, any Error>
+    ) {
+      self.locationContinuations.append(continuation)
     }
-  }
-
-  func locationManager(_: CLLocationManager, didFailWithError error: Error) {
-    self.locationReceived(.failure(LocationError.error(error as! CLError)))
-  }
-
-  @available(macOS 11, *)
-  func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
-    let status = manager.authorizationStatus
-    while !self.authorizationContinuations.isEmpty {
-      self.authorizationContinuations.removeFirst().resume(returning: status)
+    func registerAuthorizationContinuation(
+      _ continuation: CheckedContinuation<CLAuthorizationStatus, Never>
+    ) {
+      self.authorizationContinuations.append(continuation)
     }
-  }
 
-  @available(macOS, deprecated: 11)
-  func locationManager(
-    _ manager: CLLocationManager,
-    didChangeAuthorization status: CLAuthorizationStatus
-  ) {
-    while !self.authorizationContinuations.isEmpty {
-      self.authorizationContinuations.removeFirst().resume(returning: status)
+    private func locationReceived(_ res: Result<CLLocationCoordinate2D, LocationError>) {
+      while !self.locationContinuations.isEmpty {
+        self.locationContinuations.removeFirst().resume(with: res)
+      }
     }
-  }
-}
 
-extension CLAuthorizationStatus {
-  var _isAuthorized: Bool {
-    switch self {
-    case .authorized, .authorizedAlways, .authorizedWhenInUse:
-      return true
-    case .denied, .notDetermined, .restricted:
-      return false
-    @unknown default:
-      return false
-    }
-  }
-}
-
-extension LocationClient {
-  static var system: LocationClient {
-    let locationManagerDelegate = LocationManagerDelegate()
-
-    let requestWhenInUseAuthorization = { @Sendable @MainActor in
-      let status: CLAuthorizationStatus
-      if #available(macOS 11.0, *) {
-        @Dependency(\.locationManager.authorizationStatus) var authorizationStatus
-        status = authorizationStatus
+    func locationManager(_: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+      if let locationClient = locations.first {
+        self.locationReceived(.success(locationClient.coordinate))
       } else {
-        status = CLLocationManager.authorizationStatus()
-      }
-      if status._isAuthorized {
-        return status
-      }
-
-      return await withCheckedContinuation { continuation in
-        locationManagerDelegate.registerAuthorizationContinuation(continuation)
-        @Dependency(\.locationManager) var locationManager
-        locationManager.requestWhenInUseAuthorization()
+        self.locationReceived(.failure(LocationError.noLocation))
       }
     }
 
-    let _implementation = Implementation(
-      getLocation: .init {
-        @Dependency(\.locationManager) var locationManager
+    func locationManager(_: CLLocationManager, didFailWithError error: Error) {
+      self.locationReceived(.failure(LocationError.error(error as! CLError)))
+    }
+
+    @available(macOS 11, *)
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+      let status = manager.authorizationStatus
+      while !self.authorizationContinuations.isEmpty {
+        self.authorizationContinuations.removeFirst().resume(returning: status)
+      }
+    }
+
+    @available(macOS, deprecated: 11)
+    func locationManager(
+      _ manager: CLLocationManager,
+      didChangeAuthorization status: CLAuthorizationStatus
+    ) {
+      while !self.authorizationContinuations.isEmpty {
+        self.authorizationContinuations.removeFirst().resume(returning: status)
+      }
+    }
+  }
+
+  extension CLAuthorizationStatus {
+    var _isAuthorized: Bool {
+      switch self {
+      case .authorized, .authorizedAlways, .authorizedWhenInUse:
+        return true
+      case .denied, .notDetermined, .restricted:
+        return false
+      @unknown default:
+        return false
+      }
+    }
+  }
+
+  extension LocationClient {
+    static var system: LocationClient {
+      let requestWhenInUseAuthorization = { @Sendable @MainActor in
+        @Dependency(\.locationManager.authorizationStatus) var status
+        if status._isAuthorized {
+          return status
+        }
+
         let locationManagerDelegate = LocationManagerDelegate()
 
-        locationManager.delegate = locationManagerDelegate
-        locationManager.desiredAccuracy = locationManager.desiredAccuracy
-        locationManager.activityType = .fitness
+        return await withCheckedContinuation { continuation in
+          locationManagerDelegate.registerAuthorizationContinuation(continuation)
+          @Dependency(\.locationManager) var locationManager
+          locationManager.requestWhenInUseAuthorization()
+        }
+      }
 
-        if !locationManager.authorizationStatus._isAuthorized {
-          let status = await requestWhenInUseAuthorization()
-          if !status._isAuthorized {
-            throw LocationError.notAuthorized(status)
+      let _implementation = Implementation(
+        getLocation: .init {
+          @Dependency(\.locationManager) var locationManager
+          let locationManagerDelegate = LocationManagerDelegate()
+
+          locationManager.delegate = locationManagerDelegate
+          locationManager.desiredAccuracy = locationManager.desiredAccuracy
+          locationManager.activityType = .fitness
+
+          if !locationManager.authorizationStatus._isAuthorized {
+            let status = await requestWhenInUseAuthorization()
+            if !status._isAuthorized {
+              throw LocationError.notAuthorized(status)
+            }
           }
+
+          let locationClient = try await withCheckedThrowingContinuation { continuation in
+            locationManagerDelegate.registerLocationContinuation(continuation)
+            locationManager.requestLocation()
+          }
+
+          return locationClient
         }
+      )
+      return LocationClient(_implementation: _implementation)
+    }
 
-        let location = try await withCheckedThrowingContinuation { continuation in
-          locationManagerDelegate.registerLocationContinuation(continuation)
-          locationManager.requestLocation()
-        }
-
-        // Stop updating location as `requestLocation` starts it.
-        // Without this, calling `requestLocation` a second time does nothing.
-        //        locationManager.stopUpdatingLocation()
-
-        return location
-      }
-    )
-    return LocationClient(_implementation: _implementation)
+    static let unimplemented = LocationClient(
+      _implementation: .init(
+        getLocation: .unimplemented(
+          #"@Dependency(\.locationClient.getLocation)"#)
+      ))
   }
-
-  static var preview: LocationClient {
-    let authorized: CLAuthorizationStatus
-#if os(macOS)
-    authorized = .authorized
-#else
-    authorized = .authorizedAlways
-#endif
-
-    return LocationClient(
-      authorizationStatus: { authorized },
-      requestWhenInUseAuthorization: { authorized },
-      requestAlwaysAuthorization: { authorized },
-      getLocation: { _ in
-        // Coordinates of the "Dame du Lac" spot in Lisses, France
-        CLLocationCoordinate2D(latitude: 48.61739, longitude: 2.41905)
-      }
-    )
-  }
-
-  static let unimplemented = LocationClient(
-    authorizationStatus: unimplemented("LocationClient.authorizationStatus", placeholder: .denied),
-    requestWhenInUseAuthorization: unimplemented("LocationClient.requestWhenInUseAuthorization", placeholder: .denied),
-    requestAlwaysAuthorization: unimplemented("LocationClient.requestAlwaysAuthorization", placeholder: .denied),
-    getLocation: unimplemented("LocationClient.getLocation")
-  )
-}
 
 #endif

--- a/Sources/_LocationDependency/LocationDependency.swift
+++ b/Sources/_LocationDependency/LocationDependency.swift
@@ -1,0 +1,191 @@
+#if canImport(CoreLocation)
+  @preconcurrency import CoreLocation
+  import Dependencies
+  @_spi(Internals) import DependenciesAdditionsBasics
+  import LocationManagerDependency
+
+  extension DependencyValues {
+    /// An abstraction of `CLLocationManager`, the central object for managing
+    /// notification-related activities for your app or app extension.
+    public var location: LocationClient {
+      get { self[LocationClient.self] }
+      set { self[LocationClient.self] = newValue }
+    }
+  }
+
+  extension LocationClient: DependencyKey {
+    public static var liveValue: LocationClient { .system }
+    public static var testValue: LocationClient { .unimplemented }
+    public static var previewValue: LocationClient { .system }
+  }
+
+  public struct LocationClient: Sendable, ConfigurableProxy {
+    public struct Implementation: Sendable {
+      // TODO: Try to add `@MainActor`
+      @FunctionProxy public var getLocation: @Sendable () async throws -> CLLocationCoordinate2D
+    }
+
+    @_spi(Internals) public var _implementation: Implementation
+  }
+
+
+
+
+enum LocationError: Error {
+  case noLocation, notAuthorized(CLAuthorizationStatus), error(CLError)
+}
+
+enum DelegateError: Swift.Error {
+  case deinitialized
+}
+
+
+final class LocationManagerDelegate: NSObject, CLLocationManagerDelegate {
+  private var locationContinuations: [CheckedContinuation<CLLocationCoordinate2D, any Error>] = []
+  private var authorizationContinuations: [CheckedContinuation<CLAuthorizationStatus, Never>] = []
+
+  deinit {
+    while !self.locationContinuations.isEmpty {
+      self.locationContinuations.removeFirst().resume(throwing: DelegateError.deinitialized)
+    }
+  }
+
+  func registerLocationContinuation(_ continuation: CheckedContinuation<CLLocationCoordinate2D, any Error>) {
+    self.locationContinuations.append(continuation)
+  }
+  func registerAuthorizationContinuation(_ continuation: CheckedContinuation<CLAuthorizationStatus, Never>) {
+    self.authorizationContinuations.append(continuation)
+  }
+
+  private func locationReceived(_ res: Result<CLLocationCoordinate2D, LocationError>) -> Void {
+    while !self.locationContinuations.isEmpty {
+      self.locationContinuations.removeFirst().resume(with: res)
+    }
+  }
+
+  func locationManager(_: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+    if let location = locations.first {
+      self.locationReceived(.success(location.coordinate))
+    } else {
+      self.locationReceived(.failure(LocationError.noLocation))
+    }
+  }
+
+  func locationManager(_: CLLocationManager, didFailWithError error: Error) {
+    self.locationReceived(.failure(LocationError.error(error as! CLError)))
+  }
+
+  @available(macOS 11, *)
+  func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+    let status = manager.authorizationStatus
+    while !self.authorizationContinuations.isEmpty {
+      self.authorizationContinuations.removeFirst().resume(returning: status)
+    }
+  }
+
+  @available(macOS, deprecated: 11)
+  func locationManager(
+    _ manager: CLLocationManager,
+    didChangeAuthorization status: CLAuthorizationStatus
+  ) {
+    while !self.authorizationContinuations.isEmpty {
+      self.authorizationContinuations.removeFirst().resume(returning: status)
+    }
+  }
+}
+
+extension CLAuthorizationStatus {
+  var _isAuthorized: Bool {
+    switch self {
+    case .authorized, .authorizedAlways, .authorizedWhenInUse:
+      return true
+    case .denied, .notDetermined, .restricted:
+      return false
+    @unknown default:
+      return false
+    }
+  }
+}
+
+extension LocationClient {
+  static var system: LocationClient {
+    let locationManagerDelegate = LocationManagerDelegate()
+
+    let requestWhenInUseAuthorization = { @Sendable @MainActor in
+      let status: CLAuthorizationStatus
+      if #available(macOS 11.0, *) {
+        @Dependency(\.locationManager.authorizationStatus) var authorizationStatus
+        status = authorizationStatus
+      } else {
+        status = CLLocationManager.authorizationStatus()
+      }
+      if status._isAuthorized {
+        return status
+      }
+
+      return await withCheckedContinuation { continuation in
+        locationManagerDelegate.registerAuthorizationContinuation(continuation)
+        @Dependency(\.locationManager) var locationManager
+        locationManager.requestWhenInUseAuthorization()
+      }
+    }
+
+    let _implementation = Implementation(
+      getLocation: .init {
+        @Dependency(\.locationManager) var locationManager
+        let locationManagerDelegate = LocationManagerDelegate()
+
+        locationManager.delegate = locationManagerDelegate
+        locationManager.desiredAccuracy = locationManager.desiredAccuracy
+        locationManager.activityType = .fitness
+
+        if !locationManager.authorizationStatus._isAuthorized {
+          let status = await requestWhenInUseAuthorization()
+          if !status._isAuthorized {
+            throw LocationError.notAuthorized(status)
+          }
+        }
+
+        let location = try await withCheckedThrowingContinuation { continuation in
+          locationManagerDelegate.registerLocationContinuation(continuation)
+          locationManager.requestLocation()
+        }
+
+        // Stop updating location as `requestLocation` starts it.
+        // Without this, calling `requestLocation` a second time does nothing.
+        //        locationManager.stopUpdatingLocation()
+
+        return location
+      }
+    )
+    return LocationClient(_implementation: _implementation)
+  }
+
+  static var preview: LocationClient {
+    let authorized: CLAuthorizationStatus
+#if os(macOS)
+    authorized = .authorized
+#else
+    authorized = .authorizedAlways
+#endif
+
+    return LocationClient(
+      authorizationStatus: { authorized },
+      requestWhenInUseAuthorization: { authorized },
+      requestAlwaysAuthorization: { authorized },
+      getLocation: { _ in
+        // Coordinates of the "Dame du Lac" spot in Lisses, France
+        CLLocationCoordinate2D(latitude: 48.61739, longitude: 2.41905)
+      }
+    )
+  }
+
+  static let unimplemented = LocationClient(
+    authorizationStatus: unimplemented("LocationClient.authorizationStatus", placeholder: .denied),
+    requestWhenInUseAuthorization: unimplemented("LocationClient.requestWhenInUseAuthorization", placeholder: .denied),
+    requestAlwaysAuthorization: unimplemented("LocationClient.requestAlwaysAuthorization", placeholder: .denied),
+    getLocation: unimplemented("LocationClient.getLocation")
+  )
+}
+
+#endif

--- a/Tests/_LocationDependencyTests/LocationDependencyTests.swift
+++ b/Tests/_LocationDependencyTests/LocationDependencyTests.swift
@@ -1,0 +1,121 @@
+#if canImport(CoreLocation)
+  import CoreLocation
+  import Dependencies
+  @_spi(Internals) import DependenciesAdditionsBasics
+  import LocationManagerDependency
+  import XCTest
+  import _LocationDependency
+
+  final class LocationDependencyTests: XCTestCase {
+    func testGetLocation() async throws {
+      try await withDependencies {
+        let coordinate = IncrementingCoordinateGenerator()
+
+        $0.locationClient.$getLocation = { @Sendable in coordinate() }
+      } operation: {
+        @Dependency(\.locationClient) var locationClient
+
+        var location = try await locationClient.getLocation()
+        XCTAssertEqual(location.latitude, 0)
+
+        location = try await locationClient.getLocation()
+        XCTAssertEqual(location.latitude, 1)
+      }
+    }
+
+    func testDesiredAccuracy() async throws {
+      // This is the desired behavior
+      let manager1 = CLLocationManager()
+      let manager2 = CLLocationManager()
+      manager1.desiredAccuracy = 1
+      manager2.desiredAccuracy = 2
+      XCTAssertEqual(manager1.desiredAccuracy, 1)
+      XCTAssertEqual(manager2.desiredAccuracy, 2)
+
+      final class Model {
+        @Dependency(\.locationManager) var locationManager
+        @Dependency(\.locationClient) var locationClient
+      }
+
+      let (model1, model2) = withDependencies {
+        let coordinate = IncrementingCoordinateGenerator()
+        $0.locationClient.$getLocation = { @Sendable in
+          @Dependency(\.locationManager) var locationManager
+          let coordinate = coordinate()
+          if locationManager.desiredAccuracy == kCLLocationAccuracyReduced {
+            return CLLocationCoordinate2D(
+              latitude: coordinate.latitude * 100,
+              longitude: coordinate.longitude * 100
+            )
+          } else {
+            return coordinate
+          }
+        }
+      } operation: {
+        let model1 = Model()
+        let model2 = withDependencies {
+          // The second model has a different `locationManager` instance,
+          // so it can set a custom desired accuracy.
+          $0.locationManager = .testValue
+        } operation: {
+          Model()
+        }
+        return (model1, model2)
+      }
+
+      // Both models need different accuracies
+      model1.locationManager.desiredAccuracy = kCLLocationAccuracyBest
+      model2.locationManager.desiredAccuracy = kCLLocationAccuracyReduced
+      XCTAssertEqual(model1.locationManager.desiredAccuracy, kCLLocationAccuracyBest)
+      XCTAssertEqual(model2.locationManager.desiredAccuracy, kCLLocationAccuracyReduced)
+
+      // Getting the location from the first model gives accurate coordinates
+      try await withDependencies(from: model1) {
+        $0.locationManager.$desiredAccuracy = .constant(kCLLocationAccuracyBest)
+      } operation: {
+        var location = try await model1.locationClient.getLocation()
+        XCTAssertEqual(location.latitude, 0)
+
+        location = try await model1.locationClient.getLocation()
+        XCTAssertEqual(location.latitude, 1)
+      }
+
+      // Getting the location from the second model gives inaccurate coordinates
+      try await withDependencies(from: model2) {
+        $0.locationManager.$desiredAccuracy = .constant(kCLLocationAccuracyReduced)
+      } operation: {
+        var location = try await model2.locationClient.getLocation()
+        XCTAssertEqual(location.latitude, 200)
+
+        location = try await model2.locationClient.getLocation()
+        XCTAssertEqual(location.latitude, 300)
+      }
+
+      // Changing the accuracy on one model changes the accuracy of the results
+      do {
+        XCTAssertEqual(model1.locationManager.desiredAccuracy, kCLLocationAccuracyBest)
+        var location = try await model1.locationClient.getLocation()
+        XCTAssertEqual(location.latitude, 4)
+
+        model1.locationManager.desiredAccuracy = kCLLocationAccuracyReduced
+
+        location = try await model1.locationClient.getLocation()
+        XCTAssertEqual(location.latitude, 500)
+      }
+    }
+  }
+
+  private final class IncrementingCoordinateGenerator: @unchecked Sendable {
+    private let lock = NSLock()
+    private var sequence: CLLocationDegrees = 0
+
+    func callAsFunction() -> CLLocationCoordinate2D {
+      self.lock.lock()
+      defer {
+        self.sequence += 1
+        self.lock.unlock()
+      }
+      return CLLocationCoordinate2D(latitude: self.sequence, longitude: self.sequence)
+    }
+  }
+#endif


### PR DESCRIPTION
I added a more ergonomic location dependency, as introduced in #72.

Closes #71

Checklist:

- Build for
  - [x] iOS
  - [x] macOS
  - [x] macCatalyst
  - [x] tvOS
  - [x] watchOS
  - [ ] Linux
- [x] Format
- [ ] Build with strict concurrency checking
- [x] Add tests
